### PR TITLE
CMakesLists.txt: fix static build with pcap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,21 @@ include_directories(src)
 
 
 set(_LIBPCAP "")
-FIND_PATH(PCAP_INCLUDE_DIR NAMES pcap/pcap.h)
-FIND_LIBRARY(PCAP_LIBRARY NAMES pcap)
-
-if (PCAP_LIBRARY)
+find_package(PkgConfig)
+pkg_check_modules(PCAP libpcap)
+if (PCAP_FOUND)
     add_definitions(-DHAS_LIBPCAP)
-    include_directories(${PCAP_INCLUDE_DIR})
-    set(_LIBPCAP ${PCAP_LIBRARY})
+    include_directories(${PCAP_INCLUDE_DIRS})
+    set(_LIBPCAP ${PCAP_LIBRARIES})
+else()
+    FIND_PATH(PCAP_INCLUDE_DIR NAMES pcap/pcap.h)
+    FIND_LIBRARY(PCAP_LIBRARY NAMES pcap)
+
+    if (PCAP_LIBRARY)
+        add_definitions(-DHAS_LIBPCAP)
+        include_directories(${PCAP_INCLUDE_DIR})
+        set(_LIBPCAP ${PCAP_LIBRARY})
+    endif()
 endif()
 
 add_library(libef STATIC


### PR DESCRIPTION
Use pkg-config to find the dependencies of pcap such as libnl otherwise
a static-only build will fail on:

```
[100%] Linking C executable ef
/srv/storage/autobuild/run/instance-0/output-1/host/opt/ext-toolchain/bin/../lib/gcc/arm-buildroot-linux-uclibcgnueabi/8.3.0/../../../../arm-buildroot-linux-uclibcgnueabi/bin/ld: /srv/storage/autobuild/run/instance-0/output-1/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/lib/libpcap.a(pcap-linux.o): in function `nl80211_init':
pcap-linux.c:(.text+0x460): undefined reference to `nl_socket_alloc'
/srv/storage/autobuild/run/instance-0/output-1/host/opt/ext-toolchain/bin/../lib/gcc/arm-buildroot-linux-uclibcgnueabi/8.3.0/../../../../arm-buildroot-linux-uclibcgnueabi/bin/ld: pcap-linux.c:(.text+0x498): undefined reference to `genl_connect'

```

Fixes:
 - http://autobuild.buildroot.org/results/99062bfc8c21c32bc835acae675aede7c9cf0c90

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>