### PR TITLE
Frame stack size check added

### DIFF
--- a/src/ef-args.c
+++ b/src/ef-args.c
@@ -9,6 +9,11 @@ int argc_frame(int argc, const char *argv[], frame_t *f) {
     int i, j, res, offset;
     hdr_t *h;
 
+    if(argc > FRAME_STACK_MAX) {
+        po("ERROR: Frame stack size is too big");
+        return -1;
+    }
+
     offset = 0;
     frame_reset(f);
 


### PR DESCRIPTION
When trying to fuzz LMstax , frame stack size more than 100(FRAME_STACK_MAX)  have been sent as inputs ,which caused an out of bounds error. Hence the frame max size check added.