### PR TITLE
fix frame_clone_and_push_hdr: guard stack overflow at the push site

### DIFF
--- a/src/ef-args.c
+++ b/src/ef-args.c
@@ -9,11 +9,6 @@ int argc_frame(int argc, const char *argv[], frame_t *f) {
     int i, j, res, offset;
     hdr_t *h;
 
-    if(argc > FRAME_STACK_MAX) {
-        po("ERROR: Frame stack size is too big");
-        return -1;
-    }
-
     offset = 0;
     frame_reset(f);
 

--- a/src/ef.c
+++ b/src/ef.c
@@ -314,12 +314,10 @@ void frame_reset(frame_t *f) {
 }
 
 hdr_t *frame_clone_and_push_hdr(frame_t *f, hdr_t *h) {
-    hdr_t *new_hdr = hdr_clone(h);
+    if (f->stack_size >= FRAME_STACK_MAX)
+        return NULL;
 
-    f->stack[f->stack_size] = new_hdr;
-    f->stack_size ++;
-
-    return new_hdr;
+    return f->stack[f->stack_size++] = hdr_clone(h);
 }
 
 int hdr_parse_fields(frame_t *frame, struct hdr *hdr, int offset,


### PR DESCRIPTION
Revert the argc > FRAME_STACK_MAX check added in db43211d2c80 ("Frame stack size check added") and replace it with a proper guard in frame_clone_and_push_hdr().

# Problem

The check in argc_frame() compares argc (total remaining argv) against FRAME_STACK_MAX (the per-frame header stack depth). These are fundamentally different quantities, argc includes arguments for ALL subsequent tx/rx clauses, not just the current frame being parsed.

A single tx clause like tx eth0 eth smac ::1 dmac ::2 consumes 7 argv entries but only pushes 1 header onto the frame stack. With FRAME_STACK_MAX=200, just 29 tx clauses (29 × 7 = 203 args) trip the check even though each individual frame only uses a few stack entries.

This breaks real-world usage. For example, the switchdev test framework's FDB stress test batches 100 tx clauses into a single ef invocation:

```ruby
smacs.each_slice(100).each do |chunk|
cmd = 'ef'
chunk.each do |smac|
        cmd += " tx #{$pp[1]} eth smac #{smac} dmac #{dmac}"
end
$ts.pc.run cmd
end
```

This fails due to this argc check bug.

# Fix

Remove the `argc` check from `argc_frame()` and guard the actual array push in `frame_clone_and_push_hdr()` where `f->stack[]` is written.

`frame_clone_and_push_hdr()` is the only place that writes to `f->stack[]`, so this single guard is sufficient.
